### PR TITLE
Fix Spread operator compile error

### DIFF
--- a/src/containers/ImportModal.tsx
+++ b/src/containers/ImportModal.tsx
@@ -231,9 +231,9 @@ class ImportModal_ extends Component<ImportModalProps & ImportModalDispatch, Imp
               {petscii && !png2pet.isError(petscii) &&
                 <div>
                   <PngPreview
+                    {...toFramebuf(petscii, this.state.selectedBackgroundColor, this.state.charset)}
                     currentColorPalette={this.props.currentColorPalette}
                     charset={this.state.charset}
-                    {...toFramebuf(petscii, this.state.selectedBackgroundColor, this.state.charset)}
                   />
                   {matchedBackgroundColors.length > 1 &&
                     <div>


### PR DESCRIPTION
Fixes #210

Compiler complaints about redefining local variables by spread operator, so if local assignments are relevant (as I presume) spread operator should go first, and then local assignments.